### PR TITLE
fallback to pseudo inverse of fundamental matrix

### DIFF
--- a/src/palantir/core.py
+++ b/src/palantir/core.py
@@ -358,7 +358,8 @@ def _terminal_states_from_markov_chain(T, wp_data, pseudotime):
     # Identify terminal statses
     waypoints = wp_data.index
     dm_boundaries = pd.Index(set(wp_data.idxmax()).union(wp_data.idxmin()))
-    vals, vecs = eigs(T.T, 10)
+    n = min(*T.shape)
+    vals, vecs = eigs(T.T, 10, maxiter=n*50)
 
     ranks = np.abs(np.real(vecs[:, np.argsort(vals)[-1]]))
     ranks = pd.Series(ranks, index=waypoints)

--- a/src/palantir/core.py
+++ b/src/palantir/core.py
@@ -16,7 +16,7 @@ from scipy.sparse.linalg import eigs
 
 from scipy.sparse import csr_matrix, find, csgraph
 from scipy.stats import entropy, pearsonr, norm
-from numpy.linalg import inv
+from numpy.linalg import inv, pinv, LinAlgError
 from copy import deepcopy
 from palantir.presults import PResults
 
@@ -431,7 +431,13 @@ def _differentiation_entropy(wp_data, terminal_states, knn, n_jobs, pseudotime):
     Q = T[trans_states, :][:, trans_states]
     # Fundamental matrix
     mat = np.eye(Q.shape[0]) - Q.todense()
-    N = inv(mat)
+    try:
+        N = inv(mat)
+    except LinAlgError:
+        warnings.warn(
+            "Singular matrix encountered. Attempting pseudo-inverse.",
+        )
+        N = pinv(mat, hermitian=True)
 
     # Absorption probabilities
     branch_probs = np.dot(N, T[trans_states, :][:, abs_states].todense())

--- a/src/palantir/core.py
+++ b/src/palantir/core.py
@@ -472,8 +472,8 @@ def _connect_graph(adj, data, start_cell):
     # Idenfity unreachable nodes
     unreachable_nodes = data.index.difference(dists.index)
     if len(unreachable_nodes) > 0:
-        print(
-            "Warning: Some of the cells were unreachable. Consider increasing the k for \n \
+        warnings.warn(
+            "Some of the cells were unreachable. Consider increasing the k for \n \
             nearest neighbor graph construction."
         )
 


### PR DESCRIPTION
@ManuSetty this is just an internal PR for you to decide on before I do any PR to the official repo.

The PR addresses the case of singular fundamental matrices that I have been encountering more often using the HSC data.
The implementation warns the user if the fundamental matrix is singular and falls back to a pseudo inverse:

![image](https://github.com/dpeerlab/Palantir/assets/4857068/a2eaa14f-6857-4363-9bbd-62b45a289f80)

The results seem consistent with similar settings of Palantir that do not produce a singular matrix.